### PR TITLE
 Dev-69 Heartbeat > goto.tm create redirect doesn't work anymore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,6 @@ FREEDOM_ACCOUNTS_URI=http://api.accounts.freedom.tm
 FREEDOM_ACCOUNTS_CALLBACK=http://goto.tm/au/callback
 FREEDOM_ACCOUNTS_CLIENTID=
 FREEDOM_ACCOUNTS_SECRET=
+
+#Third Party URL Request Access Code
+THIRD_PARTY_ACCESS_CODE=a9069a16-c422-4ce8-8ab1-a30eeb4620e6

--- a/app/Http/Controllers/Api/ThirdPartyController.php
+++ b/app/Http/Controllers/Api/ThirdPartyController.php
@@ -36,7 +36,9 @@ class ThirdPartyController extends Controller
             Rule::create($input);
         } catch (Exception $ex) {
             return response()->json([
-                'message' => 'Server failed to create redirect rule'
+                'message' =>
+                    'Server failed to create redirect rule: ' .
+                    $ex->getMessage()
             ], 500);
         };
 

--- a/app/Http/Controllers/Api/ThirdPartyController.php
+++ b/app/Http/Controllers/Api/ThirdPartyController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use Illuminate\Http\Request;
 
 use Input;
+use Validator;
 use App\Rule;
 use App\Http\Requests;
 use App\Http\Controllers\Controller;
@@ -20,11 +21,28 @@ class ThirdPartyController extends Controller
     public function postLink () {
         $input = Input::only('short_url', 'long_url');
 
-        Rule::create($input);
+        $validation = Validator::make($input, [
+            'short_url' => 'required|min:2',
+            'long_url' => 'required|max:2083'
+        ]);
+
+        if ($validation->fails()) {
+            return response()->json([
+                $validation->errors()
+            ], 400);
+        }
+
+        try {
+            Rule::create($input);
+        } catch (Exception $ex) {
+            return response()->json([
+                'message' => 'Server failed to create redirect rule'
+            ], 500);
+        };
 
         return response()->json([
-          'message' => 'Successfully Created',
-          'meta' => $input
+            'message' => 'Successfully Created',
+            'meta' => $input
         ]);
     }
 }

--- a/app/Http/Controllers/Api/ThirdPartyController.php
+++ b/app/Http/Controllers/Api/ThirdPartyController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use Illuminate\Http\Request;
+
+use Input;
+use App\Rule;
+use App\Http\Requests;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\UpdateRedirectRequest;
+
+class ThirdPartyController extends Controller
+{
+
+    public function __construct() {
+        $this->middleware('third_party_access');
+    }
+
+    public function postLink () {
+        $input = Input::only('short_url', 'long_url');
+
+        Rule::create($input);
+
+        return response()->json([
+          'message' => 'Successfully Created',
+          'meta' => $input
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -73,5 +73,4 @@ class UserController extends Controller
 
         return response()->json($rule);
     }
-
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -32,5 +32,6 @@ class Kernel extends HttpKernel
         'captcha' => \App\Http\Middleware\ReCaptcha::class,
         'csrf' => \App\Http\Middleware\VerifyCsrfToken::class,
         'freedom_oauth' => \App\Http\Middleware\FreedomOauth::class,
+        'third_party_access' => \App\Http\Middleware\ThirdPartyAccess::class,
     ];
 }

--- a/app/Http/Middleware/ThirdPartyAccess.php
+++ b/app/Http/Middleware/ThirdPartyAccess.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+
+use Illuminate\Http\Request;
+
+use Closure;
+
+
+class ThirdPartyAccess
+{
+    public function handle($request, Closure $next)
+    {
+        $accessToken = config('third_party.access_token');
+        $accessTokenProvided = request()->header('access_token');
+
+        if ($accessTokenProvided === $accessToken) {
+            return $next($request);
+        }
+
+        return response()->json(['message' => 'Not allowed.'], 403);
+    }
+}
+

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -23,6 +23,8 @@ Route::group(['middleware' => 'auth'], function () {
     Route::controller('/api/my', 'Api\UserController');
 });
 
+Route::controller('/api/thirdParty', 'Api\ThirdPartyController');
+
 Route::group([
     'prefix' => '/{code}',
     'where' => ['code' => '(.*)'],

--- a/config/third_party.php
+++ b/config/third_party.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'access_token' => 'a9069a16-c422-4ce8-8ab1-a30eeb4620e6'
+];


### PR DESCRIPTION
- This allows third party services to create a redirect rule using an access token with the usual long and short URL parameters
